### PR TITLE
Use basic auth

### DIFF
--- a/InfluxDB.html
+++ b/InfluxDB.html
@@ -81,6 +81,16 @@
 
 
         </div>
+        <div class="row">
+                <div class="input-group mb-3 col-sm">
+                        <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="" id="useBasicAuth">
+                                <label class="form-check-label" for="useBasicAuth">
+                                  Use basic auth
+                                </label>
+                            </div>
+                </div>
+        </div>
     </div>
 
     <div class="row">
@@ -108,7 +118,18 @@
 
         </div>
     </div>
-
+    <div class="row">
+            <div class="span6" style="float: none; margin: 0 auto;">
+        <big>or</big>
+            </div>
+    </div>
+    <div class="row">
+            <div class="input-group mb-3 col-sm">
+                    <input type="text" class="form-control" aria-label="..." placeholder="Enter a base url to use for Influx requests - this overrides the server settings above" id="baseurl">
+                </div>
+        
+        
+    </div>
 
     <div class="row mb-3 dflex flex-row">
         <h4 class="col-sm">2. Databases</h4>

--- a/InfluxDB.html
+++ b/InfluxDB.html
@@ -125,7 +125,7 @@
     </div>
     <div class="row">
             <div class="input-group mb-3 col-sm">
-                    <input type="text" class="form-control" aria-label="..." placeholder="Enter a base url to use for Influx requests - this overrides the server settings above" id="baseurl">
+                    <input type="text" class="form-control" aria-label="..." placeholder="Enter a base url to use for Influx requests - this overrides the server settings above" id="baseUrl">
                 </div>
         
         

--- a/InfluxDB_WDC.js
+++ b/InfluxDB_WDC.js
@@ -612,7 +612,6 @@
         if (useAuth) { setAuth(); }
           var queryString_DBs = getInfluxURL('/query?q=SHOW+DATABASES');
           if (debug) console.log('Retrieving databases with querystring: ', queryString_DBs);
-          console.log('username:' + username + ' password:' + password);
           $.ajax({
             beforeSend: function (xhr) {
               /* Authorization header */

--- a/InfluxDB_WDC.js
+++ b/InfluxDB_WDC.js
@@ -193,8 +193,9 @@
       }
 
     }).done(function (resp) {
+      console.log('retrieved all measurements: %o', resp);
       if (debug) console.log('retrieved all measurements: %o', resp);
-      if (debug) console.log('resp.results[0].series[0].values: %o', resp.results[0].series[0].values);
+      // if (debug) console.log('resp.results[0].series[0].values: %o', resp.results[0].series[0].values);
 
       // for each measurement, save the async function to a "factory" array
       var deferreds = (resp.results[0].series[0].values).map(function (measurement, index) {

--- a/InfluxDB_WDC.js
+++ b/InfluxDB_WDC.js
@@ -7,7 +7,10 @@
   var db = '';
   var debug = true; // set to true to enable JS Console debug messages
   var protocol = 'http://'; // default to non-encrypted.  To setup InfluxDB with https see https://docs.influxdata.com/influxdb/v1.2/administration/https_setup/
-  var useAuth = false; // bool to include/prompt for username/password
+  var baseUrl = '';
+  //TODO: reset this to false
+  var useAuth = true; // bool to include/prompt for username/password
+  var useBasicAuth = false;
   var username = '';
   var password = '';
   var queryString_Auth; // string to hold the &u=_user_&p=_pass_ part of the query string
@@ -637,6 +640,8 @@
       schema: schema,
       customSql: customSql,
       customSqlSplit: customSqlSplit,
+      useBasicAuth: useBasicAuth,
+      baseUrl: baseUrl
     };
     if (useAuth) {
       tableau.username = username;
@@ -1141,8 +1146,11 @@
             interval_measure = json.interval_measure;
             interval_measure_string = json.interval_measure_string;
             aggregation = json.aggregation;
+            baseUrl = json.baseUrl;
 
             // set all HTML elements
+            $('#baseUrl').val(json.baseUrl);
+
             $('#servername')
               .val(json.server);
             $('#servername')
@@ -1199,6 +1207,10 @@
                 .val(tableau.username);
               $('#password')
                 .val('');
+                if (json.useBasicAuth === true) {
+                  useBasicAuth = true;
+                  $('#useBasicAuth').prop('checked', true);
+                }
             } else {
               $('#authGroup')
                 .collapse('hide');

--- a/InfluxDB_WDC.js
+++ b/InfluxDB_WDC.js
@@ -60,8 +60,17 @@
     if (debug) console.log('Retrieving tags with query: %s', queryString_tags);
     // Create a JQuery Promise object
     var deferred = $.Deferred();
-    
-    $.getJSON(queryString_tags, function (tags) {
+    $.ajax({
+      url:queryString_tags,
+      dataType:"json",
+      beforeSend: function (xhr) {
+        /* Authorization header */
+        if (useBasicAuth) {
+          xhr.setRequestHeader("Authorization", "Basic " + btoa(username + ':' + password));
+        }
+      }
+
+    }).done(function (tags) {
       if (debug) console.log('tag query string for ' + index + ': ' + JSON.stringify(tags));
 
       // this if statement checks to see if there is an empty series (just skip it)
@@ -98,7 +107,17 @@
   function queryStringFields(index, queryString_fields) {
     var deferred = $.Deferred();
     if (debug) console.log('Retrieving fields with query: %s', queryString_fields);
-    $.getJSON(queryString_fields, function (fields) {
+    $.ajax({
+      url:queryString_fields,
+      dataType:"json",
+      beforeSend: function (xhr) {
+        /* Authorization header */
+        if (useBasicAuth) {
+          xhr.setRequestHeader("Authorization", "Basic " + btoa(username + ':' + password));
+        }
+      }
+
+    }).done(function (fields) {
       // this if statement checks to see if there is an empty series (just skip it)
       // empty resultset: tag query string for 7: {"results":[{"statement_id":0}]}
       if (fields.results[0].hasOwnProperty('series')) {
@@ -163,7 +182,17 @@
   function getMeasurements(db, queryString) {
     // Get all measurements (aka Tables) from the DB
 
-    $.getJSON(queryString, function (resp) {
+    $.ajax({
+      url:queryString,
+      dataType:"json",
+      beforeSend: function (xhr) {
+        /* Authorization header */
+        if (useBasicAuth) {
+          xhr.setRequestHeader("Authorization", "Basic " + btoa(username + ':' + password));
+        }
+      }
+
+    }).done(function (resp) {
       if (debug) console.log('retrieved all measurements: %o', resp);
       if (debug) console.log('resp.results[0].series[0].values: %o', resp.results[0].series[0].values);
 
@@ -285,7 +314,6 @@
     var deferred = new $.Deferred();
     if (debug) { console.log ('getCustomSqlSchema'); }
     
-    //$.getJSON(queryString)
     $.ajax({
       url:queryString,
       dataType:"json",

--- a/InfluxDB_WDC.js
+++ b/InfluxDB_WDC.js
@@ -8,7 +8,7 @@
   var debug = true; // set to true to enable JS Console debug messages
   var protocol = 'http://'; // default to non-encrypted.  To setup InfluxDB with https see https://docs.influxdata.com/influxdb/v1.2/administration/https_setup/
   var baseUrl = null;
-  //TODO: reset this to false
+  
   var useAuth = false; // bool to include/prompt for username/password
   var useBasicAuth = false;
   var username = '';
@@ -279,7 +279,7 @@
   function getInfluxURL(suffix)
   {
     var out = '';
-    //TODO:we'll need to plumb in some basic auth here
+
     if (baseUrl)
     {
       //use the base URL and strip off trailing slash if added


### PR DESCRIPTION
Because reasons, we have to access InfluxDB through nginx as a rev proxy with basic auth and not at the root, so this introduces two big changes:

1. A thing called `baseUrl` which if specified is used in place of the connection options: a new method getInfluxUrl() spits out the final bits you need
2. A checkbox to use Basic Auth instead of Influx Auth